### PR TITLE
🤖 AI 新聞 2026/4/1：OpenAI 1220億融资等5則

### DIFF
--- a/ai-news-2026-04-01.md
+++ b/ai-news-2026-04-01.md
@@ -1,0 +1,63 @@
+# 🤖 Mary AI 新聞簡報 - 2026/4/1
+
+**📅 資料來源：** TechCrunch、The Verge（2026/3/31）
+
+---
+
+## 💰 OpenAI 完成 1220 億美元融资：估值 8520 億、GPT-5.4 推動營收成長
+
+OpenAI 宣布完成史上最大規模融资，累計集資 1220 億美元，公司估值達 8520 億美元。本輪由 SoftBank 與 Andreessen Horowitz 聯合領投，Amazon、Nvidia、Microsoft 均有參與，其中 30 億美元來自散戶投資者。OpenAI 還將獲 ARK Invest 納入多檔 ETF，為 IPO 做準備。
+
+公司同時公布關鍵營運數據：每月營收已達 20 億美元，ChatGPT 週活躍用戶突破 9 億，訂閱人數超過 5000 萬，搜尋使用量年增近 3 倍。廣告試驗產品上線不到六週 ARR 已破 1 億美元。企業營收占比從去年的約 30% 升至 40%，預計 2026 年底企業與消費者營收將達到持平。
+
+> 📖 來源：[TechCrunch](https://techcrunch.com/2026/03/31/openai-not-yet-public-raises-3b-from-retail-investors-in-monster-122b-fund-raise/)｜2026/3/31
+
+---
+
+## 🔓 Anthropic 一週內第二起資安事故：Claude Code 512,000 行原始碼遭洩露至 NPM
+
+Anthropic 在短短一週內發生第二起重大資安事故。該公司發布 Claude Code v2.1.88 版本時，意外將近 2000 個原始碼文件與超過 51.2 萬行程式碼打包進 NPM 安裝包，導致其核心產品架構藍圖完全暴露。安全研究人員第一時間發現並公佈於社群。
+
+這已是 Anthropic 本週第二次出事。上週四，Fortune 報導該公司近 3000 個內部文件（含未發布新模型內部代號「Mythos」）曾在未加密資料庫中短暫公開。Anthropic 將兩次事故均定性為「人為包裝錯誤，非資安漏洞」。
+
+Claude Code 是 Anthropic 的主力開發者工具，可讓 AI 代寫與修改程式碼，據報導已對 OpenAI 旗下產品造成競爭壓力，甚至間接導致 OpenAI 終止 Sora 影片生成服務。
+
+> 📖 來源：[TechCrunch](https://techcrunch.com/2026/03/31/anthropic-is-having-a-month/)｜2026/3/31
+
+---
+
+## 💬 Salesforce 為 Slack 大翻新：30 項 AI 新功能、Slackbot 化身智慧代理人
+
+Salesforce 在舊金山舉辦小型發表會，執行長 Marc Benioff 公布 Slack 史上最大規模 AI 更新，一口氣推出 30 項新功能。最核心的升級是 Slackbot 已從簡單聊天機器人進化為具備代理能力的 AI 助理。
+
+新功能亮點包括：用戶可自訂「AI Skills」工作流程（如一鍵生成活動預算並自動邀請相關同事）、Slackbot 現支援 MCP 協定可串接外部服務與 Agentforce、會議即時轉錄與摘要、還能監控桌面活動來主動給出建議。
+
+此外，Slackbot 現在可以跨 Slack 外部運作，整合用戶的交易、對話、行事曆與工作習慣，主動擬定行動方案或草擬後續追蹤。
+
+> 📖 來源：[TechCrunch](https://techcrunch.com/2026/03/31/salesforce-announces-an-ai-heavy-makeover-for-slack-with-30-new-features/)｜2026/3/31
+
+---
+
+## 📈 AI 新創天使輪估值狂飆：YC 學員喊出 4000 萬估值、Cursor 12 個月破 1 億 ARR
+
+矽谷創投與創業者共同觀察到一個趨勢：AI 新創的天使輪估值正以前所未有的速度飆漲。根據 TechCrunch 報導，近期 Y Combinator Demo Day 的新創公司中，多家僅成立八週就已拿下 6-7 位數客戶合約，卻直接喊出 500 萬美元融资、4000 萬美元 post-money 估值。
+
+Realm 執行長 Pete Martin 回憶 2024 年以 2500 萬美元估值融资 500 萬美元，坦言「當時已覺得很高，如今來看卻是市場行情」。現在常見的條件是 1000 萬美元融资、4000-4500 萬美元 post-money 估值——前提是你是 AI 公司。
+
+投資人與創業者均指出，Cursor 2025 年初達成 12 個月 1 億美元 ARR 的表現樹立了新標竿，讓創投們相信：現在不投，下一檔 IPO 就沒你的份。
+
+> 📖 來源：[TechCrunch](https://techcrunch.com/2026/03/31/its-not-your-imagination-ai-seed-startups-are-commanding-higher-valuations/)｜2026/3/31
+
+---
+
+## � Nothing 進軍 AI 眼鏡：預計 2027 年上半年推出、對標 Meta Ray-Ban
+
+根據 Bloomberg 記者 Mark Gurman 報導，以 Nothing Phone 聞名的消費電子品牌 Nothing 正積極布局 AI 眼鏡，預計 2027 年上半年正式發表。產品將配備相機、麥克風與揚声器，AI 處理則卸载到用戶手機與雲端。
+
+Nothing 並非首家進入 AI 眼鏡領域的公司——Meta Ray-Ban 智慧眼鏡已搶佔先機，Google 在 I/O 大會上也預告了新款 Android XR 眼鏡。但 Nothing 以獨特設計美學著稱，其產品定位可能瞄準時尚導向的消費群，與 Meta 的科技導向策略形成差異化。
+
+> 📖 來源：[The Verge](https://www.theverge.com)｜2026/3/31
+
+---
+
+*🤖 Mary AI 新聞簡報｜由 OpenClaw 自動蒐集與翻譯*


### PR DESCRIPTION
🤖 Mary AI 新聞簡報 2026/4/1｜由 OpenClaw Cron 自動生成

## 本次更新 5 則 AI 新聞

1. **OpenAI 完成 1220 億美元融资** - 估值 8520 億、GPT-5.4 推動營收成長、ChatGPT 週活躍用戶突破 9 億
2. **Anthropic Claude Code 原始碼洩漏** - 一週內第二起資安事故、512,000 行程式碼暴露至 NPM
3. **Salesforce Slack 30 項 AI 新功能** - Slackbot 化身智慧代理人、可自訂 AI Skills 工作流程
4. **AI 新創天使輪估值狂飆** - YC 新創喊出 4000 萬美元估值、Cursor 12 個月破 1 億 ARR
5. **Nothing 進軍 AI 眼鏡** - 預計 2027 年上半年推出、對標 Meta Ray-Ban